### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/gromacs/analysis/core.py
+++ b/gromacs/analysis/core.py
@@ -396,7 +396,7 @@ class Simulation(object):
         If no *plugin_name* is supplied to :meth:`run`, :meth:`analyze` etc. then
         this will be used.
         """
-        if plugin_name == None:
+        if plugin_name is None:
             self.default_plugin_name = None
         else:
             self.check_plugin_name(plugin_name)
@@ -663,7 +663,7 @@ class Plugin(object):
         :meth:`~Worker.analyze`, and :meth:`~Worker.plot` methods.
         """
 
-        assert simulation != None                      # must know who we belong to
+        assert simulation is not None                      # must know who we belong to
         assert self.__is_registered == False           # only register once (necessary?)
 
         self.simulation = simulation                   # update our own

--- a/gromacs/analysis/plugins/proteinonly.py
+++ b/gromacs/analysis/plugins/proteinonly.py
@@ -167,7 +167,7 @@ class _ProteinOnly(Worker):
         newfiles = self.transformer.keep_protein_only(**kwargs)
         self.parameters.filenames.update(newfiles)
 
-        if fit != None:
+        if fit is not None:
             if self.parameters.fit == "xy":
                 xy = True
             else:

--- a/gromacs/analysis/plugins/stripwater.py
+++ b/gromacs/analysis/plugins/stripwater.py
@@ -197,7 +197,7 @@ class _StripWater(Worker):
         newfiles = self.transformer.strip_water(**kwargs)
         self.parameters.filenames.update(newfiles)
 
-        if fit != None:
+        if fit is not None:
             if self.parameters.fit == "xy":
                 xy = True
             else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Becksteinlab:GromacsWrapper?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:Becksteinlab:GromacsWrapper?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)