### PR TITLE
Updated config to be compatible with Gromacs 5.1.1

### DIFF
--- a/gromacs/templates/gromacswrapper.cfg
+++ b/gromacs/templates/gromacswrapper.cfg
@@ -1,5 +1,4 @@
 # GromacsWrapper: Global User Configuration File 
-# http://sbcb.bioch.ox.ac.uk/oliver/software/GromacsWrapper/
 
 [DEFAULT]
 
@@ -17,32 +16,27 @@ managerdir = %(configdir)s/managers
 
 [Gromacs]
 # Release of the Gromacs package to which information in this sections applies.
-release = 4.5.3
+release = 5.1.1
 
 # tools contains the file names of all Gromacs tools for which classes are generated.
 # Editing this list has only an effect when the package is reloaded.
 # (Generated with 'ls [^Gac]*' from the Gromacs bin dir)
 tools = 
-      demux.pl   g_cluster     g_dyndom       g_mdmat      g_principal  g_select    g_wham    mdrun 
-      do_dssp    g_clustsize   g_enemat       g_membed     g_protonate  g_sgangle   g_wheel   mdrun_d 
-      editconf   g_confrms     g_energy       g_mindist    g_rama       g_sham      g_x2top   mk_angndx 
-      eneconv    g_covar       g_filter       g_morph      g_rdf        g_sigeps    genbox    pdb2gmx 
-      g_anadock  g_current     g_gyrate       g_msd                     g_sorient   genconf   
-      g_anaeig   g_density     g_h2order      g_nmeig      g_rms        g_spatial   genion    tpbconv 
-      g_analyze  g_densmap     g_hbond        g_nmens      g_rmsdist    g_spol      genrestr  trjcat 
-      g_angle    g_dielectric  g_helix        g_nmtraj     g_rmsf       g_tcaf      gmxcheck  trjconv 
-      g_bar      g_dih         g_helixorient  g_order      g_rotacf     g_traj      gmxdump   trjorder 
-      g_bond     g_dipoles     g_kinetics     g_pme_error  g_rotmat     g_tune_pme  grompp    xplor2gmx.pl 
-      g_bundle   g_disre       g_lie          g_polystat   g_saltbr     g_vanhove   make_edi  xpm2ps 
-      g_chi      g_dist        g_luck         g_potential  g_sas        g_velacc    make_ndx 
-
-# Additional gromacs tools that should be made available.
-extra = 
-      g_count     g_flux 
-      a_gridcalc  a_ri3Dc  g_ri3Dc
+	gmx:cluster     gmx:dyndom      gmx:mdmat       gmx:principal  gmx:select   gmx:wham        gmx:mdrun               gmx:convert-tpr
+	gmx:do_dssp     gmx:clustsize   gmx:enemat      gmx:protonate  gmx:gangle   gmx:wheel       gmx:mdrun_d             gmx:trjcat
+	gmx:editconf    gmx:confrms     gmx:energy      gmx:mindist    gmx:rama     gmx:sham        gmx:x2top               gmx:trjconv
+	gmx:eneconv     gmx:covar       gmx:filter      gmx:morph      gmx:rdf      gmx:sigeps      gmx:solvate             gmx:pdb2gmx
+	gmx:anadock     gmx:current     gmx:gyrate      gmx:msd        gmx:sorient  gmx:genconf     gmx:insert-molecules
+	gmx:anaeig      gmx:density     gmx:h2order     gmx:nmeig      gmx:rms      gmx:spatial     gmx:genion      
+	gmx:analyze     gmx:densmap     gmx:hbond       gmx:nmens      gmx:rmsdist  gmx:spol        gmx:genrestr    
+	gmx:angle       gmx:dielectric  gmx:helix       gmx:nmtraj     gmx:rmsf     gmx:tcaf        gmx:check       
+	gmx:bar         gmx:helixorient gmx:order       gmx:rotacf     gmx:traj     gmx:dump        gmx:trjorder
+	gmx:dipoles     gmx:kinetics    gmx:pme_error   gmx:rotmat     gmx:tune_pme gmx:grompp      gmx:mk_angndx
+	gmx:bundle      gmx:disre       gmx:lie         gmx:polystat   gmx:saltbr   gmx:vanhove     gmx:make_edi    
+	gmx:chi         gmx:distance    gmx:potential   gmx:sas        gmx:velacc   gmx:make_ndx    gmx:xpm2ps
 
 # which tool groups to make available as gromacs.NAME
-groups = tools extra
+groups = tools
 
 [Logging]
 # name of the logfile that is written to the current directory
@@ -59,5 +53,3 @@ logfilename = gromacs.log
 loglevel_console = INFO
 # file     messages written to logfilename
 loglevel_file = DEBUG
-
-


### PR DESCRIPTION
Since Gromacs 5.1.x removed the use of g_* methods, instead opting only
for the new ``gmx <command>`` style, this config features the necessary
bits to use the commands this way. This configuration will *not* work
for Gromacs 4.x or earlier. We will hopefully replace this config style
with one that works for multiple versions more flexibly with #49.

Removed ``extras``, as these tools are no longer maintained and it's not
clear that they will work as expected under this config.