### PR TITLE
Tries to detect and load GMXRC automatically

### DIFF
--- a/gromacs/__init__.py
+++ b/gromacs/__init__.py
@@ -242,6 +242,17 @@ def stop_logging():
     log.clear_handlers(logger)  # this _should_ do the job...
 
 
+# Try to load environment variables setted by GMXRC
+gmxrc = config.cfg.get("Gromacs", "GMXRC")
+if gmxrc:
+    try:
+        config.set_gmxrc_environment(gmxrc)
+    except OSError:
+        logger = config.logger
+        logger.warning("Failed to automatically set the Gromacs environment"
+                       "(GMXRC)")
+
+
 # Add gromacs command **instances** to the top level.
 # These serve as the equivalence of running commands in the shell.
 # (Note that each gromacs command is actually run when the instance is

--- a/gromacs/cbook.py
+++ b/gromacs/cbook.py
@@ -200,11 +200,11 @@ one to fit.
 try:
     _define_canned_commands()
 except (OSError, ImportError, GromacsError):
-    warnings.warn("Failed to define a number of commands in gromacs.cbook. Most likely the "
-                  "Gromacs installation cannot be found --- source GMXRC!",
-                  category=GromacsImportWarning)
-    logger.error("Failed to define a number of commands in gromacs.cbook. Most likely the "
-                  "Gromacs installation cannot be found --- source GMXRC!")
+    msg = ("Failed to define a number of commands in gromacs.cbook. Most "
+          "likely the Gromacs installation cannot be found --- set GMXRC in "
+           "~/.gromacswrapper.cfg or source GMXRC directly")
+    warnings.warn(msg, category=GromacsImportWarning)
+    logger.error(msg)
 finally:
     del _define_canned_commands
 

--- a/gromacs/config.py
+++ b/gromacs/config.py
@@ -166,6 +166,11 @@ command ``gmx`` is added as a prefix::
    # Release of the Gromacs package to which information in this sections applies.
    release = 5.0.5
 
+   # GMXRC contains the path for GMXRC file which will be loaded. If not
+   provided is expected that it was sourced as usual before importing this
+   library.
+   GMXRC = /usr/local/gromacs/bin/GMXRC
+
    # tools contains the command names of all Gromacs tools for which classes are generated.
    # Editing this list has only an effect when the package is reloaded.
    # (Note that this example has a much shorter list than the actual default.)
@@ -215,7 +220,7 @@ completely transparent to the user.
 """
 from __future__ import absolute_import, with_statement
 
-import os, errno
+import os, errno, subprocess
 from ConfigParser import SafeConfigParser
 
 from pkg_resources import resource_filename, resource_listdir
@@ -480,6 +485,7 @@ class GMXConfigParser(SafeConfigParser):
           self.set('DEFAULT', 'managerdir',
                   os.path.join("%(configdir)s", os.path.basename(defaults['managerdir'])))
           self.add_section('Gromacs')
+          self.set("Gromacs", "GMXRC", "")
           self.set("Gromacs", "tools", "pdb2gmx editconf grompp genbox genion mdrun trjcat trjconv")
           self.set("Gromacs", "extra", "")
           self.set("Gromacs", "groups", "tools")
@@ -637,9 +643,24 @@ def check_setup():
 check_setup()
 
 
-
 # Gromacs tools
 # -------------
+
+#: Runs GMXRC in a subprocess and put environment variables loaded by it in
+#: this environment.
+def set_gmxrc_environment(gmxrc):
+    envvars = ['GMXPREFIX', 'GMXBIN', 'GMXLDLIB', 'GMXMAN', 'GMXDATA',
+               'GROMACS_DIR', 'LD_LIBRARY_PATH', 'MANPATH', 'PKG_CONFIG_PATH',
+               'GROMACS_DIR', 'PATH']
+    cmdargs = ['bash', '-c', ". {0} && echo {1}".format(gmxrc,
+               ' '.join(['${0}'.format(v) for v in envvars]))]
+    try:
+        out = subprocess.check_output(cmdargs)
+        out = out.strip().split()
+        for key, value in zip(envvars, out):
+            os.environ[key] = value
+    except (subprocess.CalledProcessError, OSError):
+        pass
 
 #: Python list of all tool file names. Filled from values in the tool
 #: groups in the configuration file.


### PR DESCRIPTION
This commit enables to load GMXRC automatically in most common cases. If GMXPRFIX variable is not found in the environmnet, GMXRC is ran in a subprocess and the variables exported by it are set in this environment. I do exactly the same in my weekend toy project [pslacerda/gmx](https://github.com/pslacerda/gmx). I hope it helps!