### PR TITLE
Made prefixes per-tool customizable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@ quantifiedcode-bot, orbeckst, jandom, whitead
 * removed gridmatmd plugin and GridMAT-MD.pl script (#41), fixes
   installation issues (#40)
 * Allows custom prefixes like gmx_mpi:mdrun and gmx:trjconv (#48)
+* Made it so gromacs can be imported and tools loaded even if they can't
+  be executed at improt time. 
 
 2015-12-16      0.4.0
 orbeckst, richardjgowers

--- a/CHANGES
+++ b/CHANGES
@@ -12,8 +12,8 @@ quantifiedcode-bot, orbeckst, jandom, whitead
 * removed gridmatmd plugin and GridMAT-MD.pl script (#41), fixes
   installation issues (#40)
 * Allows custom prefixes like gmx_mpi:mdrun and gmx:trjconv (#48)
-* Made it so gromacs can be imported and tools loaded even if they can't
-  be executed at improt time. 
+* Made it so GromacsWrapper can be imported and tools loaded even if they can't
+  be executed at import time. 
 
 2015-12-16      0.4.0
 orbeckst, richardjgowers

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ quantifiedcode-bot, orbeckst, jandom, whitead
   Tool calls prefixed with 'G_' will still work. (PR #46, Issue #26)
 * removed gridmatmd plugin and GridMAT-MD.pl script (#41), fixes
   installation issues (#40)
+* Allows custom prefixes like gmx_mpi:mdrun and gmx:trjconv (#48)
 
 2015-12-16      0.4.0
 orbeckst, richardjgowers

--- a/gromacs/__init__.py
+++ b/gromacs/__init__.py
@@ -259,9 +259,7 @@ for clsname, cls in tools.registry.items():
     try:
         globals()[name] = cls()                # add instance of command for immediate use
         _have_g_commands.append(name)
-    except GromacsError:                       # ignore missing -h for doc extraction
-        pass
-    except OSError:
+    except:
         _missing_g_commands.append(name)
 warnings.simplefilter("always", GromacsFailureWarning)
 warnings.simplefilter("always", GromacsImportWarning)

--- a/gromacs/__init__.py
+++ b/gromacs/__init__.py
@@ -259,7 +259,9 @@ for clsname, cls in tools.registry.items():
     try:
         globals()[name] = cls()                # add instance of command for immediate use
         _have_g_commands.append(name)
-    except:
+    except GromacsError:                       # ignore missing -h for doc extraction
+        pass
+    except OSError:
         _missing_g_commands.append(name)
 warnings.simplefilter("always", GromacsFailureWarning)
 warnings.simplefilter("always", GromacsImportWarning)

--- a/gromacs/config.py
+++ b/gromacs/config.py
@@ -187,7 +187,12 @@ and within GromacsWrapper this would become ::
 
 (The driver command is stripped and only the "command name" is used to
 identify the command. This makes it easier to migrate GromacsWrapper
-scripts from Gromacs 4.x to 5.x.)
+scripts from Gromacs 4.x to 5.x.).
+
+The driver command can be changed per-tool, allowing for mpi
+and non-mpi versions to be used. For example::
+
+tools = gmx_mpi:mdrun gmx:pdb2gmx
 
 .. Note:: Because of `changes in the Gromacs tool in 5.x`_, 
           GromacsWrapper scripts might break, even if the tool

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -612,7 +612,10 @@ class GromacsCommand(Command):
         # temporarily throttle logger to avoid reading about the help function invocation or not found
         logging.disable(logging.CRITICAL)
         try:
-            rc,header,docs = self.run('h', stdout=PIPE, stderr=PIPE, use_input=False)
+            rc,header,docs = self.run('h', stdout=PIPE, stderr=PIPE, use_input=False)            
+        except:
+            logging.critical("Invoking command {} failed when determining its doc string. Proceed with caution".format(self.command_name))
+            return "(No Gromacs documentation available)"            
         finally:
             logging.disable(logging.NOTSET)     # ALWAYS restore logging....
         m = re.match(self.doc_pattern, docs, re.DOTALL)    # keep from DESCRIPTION onwards

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -393,7 +393,7 @@ class GromacsCommand(Command):
 
     command_name = None
     driver = ""
-    doc_pattern = """.*?(?P<DOCS>(DESCRIPTION|SYNOPSIS).*)"""
+    doc_pattern = """.*?(?P<DOCS>DESCRIPTION.*)"""
     gmxfatal_pattern = """----+\n                   # ---- decorator line
             \s*Program\s+(?P<program_name>\w+),     #  Program name,
               \s+VERSION\s+(?P<version>[\w.]+)\s*\n #    VERSION 4.0.5
@@ -600,7 +600,8 @@ class GromacsCommand(Command):
 
         .. Note::
 
-           The header is on STDOUT and is ignored. The docs are read from STDERR.
+           The header is on STDOUT and is ignored. The docs are read from STDERR in GMX 4. 
+           In GMX 5, the opposite is true (Grrr)
         """
         # Uses the class-wide arguments so that 'canned invocations' in cbook
         # are accurately reflected. Might be a problem when these invocations
@@ -614,7 +615,9 @@ class GromacsCommand(Command):
             logging.disable(logging.NOTSET)     # ALWAYS restore logging....
         m = re.match(self.doc_pattern, docs, re.DOTALL)    # keep from DESCRIPTION onwards
         if m is None:
-            return "(No Gromacs documentation available)"
+            m = re.match(self.doc_pattern, header, re.DOTALL)    # Try now with GMX 5 approach            
+            if m is None:
+                return "(No Gromacs documentation available)"
         return m.group('DOCS')
 
     @property

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -392,7 +392,7 @@ class GromacsCommand(Command):
     # TODO: setup the environment from GMXRC (can use env=DICT in Popen/call)
 
     command_name = None
-    driver = ""
+    driver = None
     doc_pattern = """.*?(?P<DOCS>DESCRIPTION.*)"""
     gmxfatal_pattern = """----+\n                   # ---- decorator line
             \s*Program\s+(?P<program_name>\w+),     #  Program name,
@@ -587,7 +587,9 @@ class GromacsCommand(Command):
 
     def _commandline(self, *args, **kwargs):
         """Returns the command line (without pipes) as a list. Inserts driver if present"""
-        return [self.driver, self.command_name] + self.transform_args(*args,**kwargs)
+        if(self.driver is not None):
+            return [self.driver, self.command_name] + self.transform_args(*args,**kwargs)
+        return [self.command_name] + self.transform_args(*args,**kwargs)
 
 
     def transform_args(self,*args,**kwargs):

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -612,10 +612,7 @@ class GromacsCommand(Command):
         # temporarily throttle logger to avoid reading about the help function invocation or not found
         logging.disable(logging.CRITICAL)
         try:
-            rc,header,docs = self.run('h', stdout=PIPE, stderr=PIPE, use_input=False)            
-        except:
-            logging.critical("Invoking command {} failed when determining its doc string. Proceed with caution".format(self.command_name))
-            return "(No Gromacs documentation available)"            
+            rc,header,docs = self.run('h', stdout=PIPE, stderr=PIPE, use_input=False)
         finally:
             logging.disable(logging.NOTSET)     # ALWAYS restore logging....
         m = re.match(self.doc_pattern, docs, re.DOTALL)    # keep from DESCRIPTION onwards

--- a/gromacs/tools.py
+++ b/gromacs/tools.py
@@ -100,8 +100,9 @@ aliases5to4 = {
 
 for name in sorted(config.load_tools):
     # hack for 5.x 'gmx toolname': add as gmx:toolname
-    if name.startswith('gmx:'):
-        name = name[4:]
+    if name.find(':') != -1:
+        prefix = name.split(':')[0]
+        name = name.split(':')[1]
         #make alias for backwards compatibility
         
         #the common case of just dropping the 'g_'
@@ -119,7 +120,8 @@ for name in sorted(config.load_tools):
         clsname = name.replace('.','_').replace('-','_').capitalize()
         old_clsname = old_name.replace('.','_').replace('-','_').capitalize()
         cls = type(clsname, (GromacsGMXCommand,), {'command_name':name,
-                                                   '__doc__': "Gromacs tool 'gmx %(name)r'." % vars()})
+                                                   'driver':prefix,
+                                                   '__doc__': "Gromacs tool '%(prefix) %(name)r'." % vars()})
         #add alias for old name
         #No need to see if old_name == name since we'll just clobber the item in registry
         registry[old_clsname] = cls

--- a/gromacs/tools.py
+++ b/gromacs/tools.py
@@ -63,11 +63,14 @@ import os.path
 import tempfile
 
 from . import config
-from .core import GromacsGMXCommand, GromacsCommand, Command
+from .core import GromacsCommand, Command
 from . import utilities
 
 def _generate_sphinx_class_string(clsname):
     return ".. class:: %(clsname)s\n    :noindex:\n" % vars()
+
+#flag for 5.0 style commands
+b_gmx5 = False
 
 #: This dict holds all generated classes.
 registry = {}
@@ -80,6 +83,7 @@ aliases5to4 = {
     'grompp': 'grompp',
     'eneconv': 'eneconv',
     'sasa': 'g_sas',
+    'distance': 'g_dist',
     'convert_tpr': 'tpbconv',
     'editconf': 'editconf',
     'pdb2gmx': 'pdb2gmx',
@@ -99,8 +103,9 @@ aliases5to4 = {
 }
 
 for name in sorted(config.load_tools):
-    # hack for 5.x 'gmx toolname': add as gmx:toolname
+    # compatibility for 5.x 'gmx toolname': add as gmx:toolname
     if name.find(':') != -1:
+        b_gmx5 = True
         prefix = name.split(':')[0]
         name = name.split(':')[1]
         #make alias for backwards compatibility
@@ -119,7 +124,7 @@ for name in sorted(config.load_tools):
         # make names valid python identifiers and use convention that class names are capitalized
         clsname = name.replace('.','_').replace('-','_').capitalize()
         old_clsname = old_name.replace('.','_').replace('-','_').capitalize()
-        cls = type(clsname, (GromacsGMXCommand,), {'command_name':name,
+        cls = type(clsname, (GromacsCommand,), {'command_name':name,
                                                    'driver':prefix,
                                                    '__doc__': "Gromacs tool '%(prefix) %(name)r'." % vars()})
         #add alias for old name
@@ -220,18 +225,30 @@ class GromacsCommandMultiIndex(GromacsCommand):
 # patching up...
 
 if 'G_mindist' in registry:
+
     # let G_mindist handle multiple ndx files
     class G_mindist(GromacsCommandMultiIndex):
         """Gromacs tool 'g_mindist' (with patch to handle multiple ndx files)."""
-        command_name = 'g_mindist'
+        command_name = registry['G_mindist'].command_name
+        driver = registry['G_mindist'].driver
+        __doc__ = registry['G_mindist'].__doc__
+
     registry['G_mindist'] = G_mindist
+    if b_gmx5:
+        registry['Mindist'] = G_mindist
 
 if 'G_dist' in registry:
     # let G_dist handle multiple ndx files
     class G_dist(GromacsCommandMultiIndex):
         """Gromacs tool 'g_dist' (with patch to handle multiple ndx files)."""
-        command_name = 'g_dist'
+        command_name = registry['G_dist'].command_name
+        driver = registry['G_dist'].driver
+        __doc__ = registry['G_dist'].__doc__
+
     registry['G_dist'] = G_dist
+    if b_gmx5:
+        registry['Distance'] = G_dist
+
 
 # TODO: generate multi index classes via type(), not copy&paste as above...
 


### PR DESCRIPTION
Now can do things like prefix gmx_mpi:mdrun and gmx:grompp and the commands will execute using the different prefixes (called drivers in code). Addresses Issue #48 