### PR TITLE
MDRunner can select appropriate mdrun for either Gromacs 4.x or 5.x

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ whitead, dotsdl, orbeckst
 
 * fixed: check_mdrun_success() works now for Gromacs 4 and Gromacs 5
   (issue #64)
+* fixed: MDRunner working for Gromacs 4 and Gromacs 5 (issue #64)  
 * fixed setup.energy_minimize() not falling back to single precision
   mdrun (issue #63)
 * fixed: added missing alias "gmx solvate" <--> "genbox" (issue #62)

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -270,7 +270,7 @@ class Command(object):
         try:
             p = PopenWithInput(cmd, stdin=stdin, stderr=stderr, stdout=stdout,
                                universal_newlines=True, input=input, shell=use_shell)
-        except OSError,err:
+        except OSError as err:
             logger.error(" ".join(cmd))            # log command line
             if err.errno == errno.ENOENT:
                 errmsg = "Failed to find Gromacs command %r, maybe its not on PATH or GMXRC must be sourced?" % self.command_name
@@ -495,7 +495,7 @@ class GromacsCommand(Command):
         self.failuremode = kwargs.pop('failure','raise')
         self.extra_doc = kwargs.pop('doc',None)
         self.gmxargs = self._combineargs(*args, **kwargs)
-        self.__doc__ = self.gmxdoc        
+        self.__doc__ = self.gmxdoc
 
     def failuremode():
         doc = """mode determines how the GromacsCommand behaves during failure
@@ -604,7 +604,7 @@ class GromacsCommand(Command):
 
         .. Note::
 
-           The header is on STDOUT and is ignored. The docs are read from STDERR in GMX 4. 
+           The header is on STDOUT and is ignored. The docs are read from STDERR in GMX 4.
            In GMX 5, the opposite is true (Grrr)
         """
         # Uses the class-wide arguments so that 'canned invocations' in cbook
@@ -614,15 +614,15 @@ class GromacsCommand(Command):
         # temporarily throttle logger to avoid reading about the help function invocation or not found
         logging.disable(logging.CRITICAL)
         try:
-            rc,header,docs = self.run('h', stdout=PIPE, stderr=PIPE, use_input=False)            
+            rc,header,docs = self.run('h', stdout=PIPE, stderr=PIPE, use_input=False)
         except:
             logging.critical("Invoking command {} failed when determining its doc string. Proceed with caution".format(self.command_name))
-            return "(No Gromacs documentation available)"            
+            return "(No Gromacs documentation available)"
         finally:
             logging.disable(logging.NOTSET)     # ALWAYS restore logging....
         m = re.match(self.doc_pattern, docs, re.DOTALL)    # keep from DESCRIPTION onwards
         if m is None:
-            m = re.match(self.doc_pattern, header, re.DOTALL)    # Try now with GMX 5 approach            
+            m = re.match(self.doc_pattern, header, re.DOTALL)    # Try now with GMX 5 approach
             if m is None:
                 return "(No Gromacs documentation available)"
         return m.group('DOCS')
@@ -677,11 +677,13 @@ class PopenWithInput(subprocess.Popen):
             input_string = ""
         self.command_string = input_string + " ".join(self.command)
         super(PopenWithInput,self).__init__(*args,**kwargs)
+
     def communicate(self, use_input=True):
         """Run the command, using the input that was set up on __init__ (for *use_input* = ``True``)"""
         if use_input:
             return super(PopenWithInput,self).communicate(self.input)
         else:
             return super(PopenWithInput,self).communicate()
+
     def __str__(self):
         return "<Popen on %r>" % self.command_string

--- a/gromacs/run.py
+++ b/gromacs/run.py
@@ -11,12 +11,23 @@ Helper functions and classes around :class:`gromacs.tools.Mdrun`.
 
 .. autoclass:: MDrunner
    :members:
+
+.. autoclass:: MDrunnerDoublePrecision
+
+
+Example implementations
+-----------------------
+
 .. autoclass:: MDrunnerOpenMP
-.. autoclass:: MDrunnerOpenMP64
 .. autoclass:: MDrunnerMpich2Smpd
+
+
+Helper functions
+----------------
 
 .. autofunction:: check_mdrun_success
 .. autofunction:: get_double_or_single_prec_mdrun
+.. autofunction:: find_gromacs_command
 
 """
 from __future__ import absolute_import, with_statement
@@ -25,6 +36,7 @@ __docformat__ = "restructuredtext en"
 import warnings
 import subprocess
 import os.path
+import errno
 
 # logging
 import logging
@@ -37,31 +49,75 @@ from . exceptions import GromacsError, AutoCorrectionWarning
 from . import core
 from . import utilities
 
+def find_gromacs_command(commands):
+    """Return *driver* and *name* of the first command that can be found on :envvar:`PATH`"""
+
+    # We could try executing 'name' or 'driver name' but to keep things lean we
+    # just check if the executables can be found and then hope for the best.
+
+    for command in utilities.asiterable(commands):
+        if command.find(':') != -1:
+            driver = command.split(':')[0]
+            name = command.split(':')[1]
+            if utilities.which(driver):
+                break
+        else:
+            driver = None
+            name = command
+            if utilities.which(name):
+                break
+    else:
+        raise OSError(errno.ENOENT, "No Gromacs executable found in", ", ".join(commands))
+
+    return driver, name
+
+
 class MDrunner(utilities.FileUtils):
     """A class to manage running :program:`mdrun` in various ways.
 
-    In order to do complicated multiprocessor runs with mpiexec or
-    similar you need to derive from this class and override
+    In order to do complicated multiprocessor runs with mpiexec or similar you
+    need to derive from this class and override
 
     - :attr:`MDrunner.mdrun` with the path to the ``mdrun`` executable
     - :attr:`MDrunner.mpiexec` with the path to the MPI launcher
     - :meth:`MDrunner.mpicommand` with a function that returns the mpi command as a list
 
     In addition there are two methods named :meth:`prehook` and
-    :meth:`posthook` that are called right before and after the
-    process is started. If they are overriden appropriately then they
-    can be used to set up a mpi environment.
+    :meth:`posthook` that are called right before and after the process is
+    started. If they are overriden appropriately then they can be used to set
+    up a mpi environment.
 
-    The :meth:`run` method can take arguments for the
-    :program:`mpiexec` launcher but it can also be used to supersede
-    the arguments for :program:`mdrun`.
+    The :meth:`run` method can take arguments for the :program:`mpiexec`
+    launcher but it can also be used to supersede the arguments for
+    :program:`mdrun`.
 
-    .. Note:: Changing :program:`mdrun` arguments permanently changes the default arguments
-              for this instance of :class:`MDrunner`. (This is arguably a bug.)
+    The actual **mdrun** command is set in the class-level attribute
+    :attr:`mdrun`. This can be a single string or a sequence (tuple) of
+    strings. On instantiation, the first entry in :attr:`mdrun` that can be
+    found on the :envvar:`PATH` is chosen (with
+    :func:`find_gromacs_command`). The entries can follow the config file
+    syntax and denote a *driver* command (for Gromacs 5.x) that is separated
+    from the command name itself by a colon. For example, ``gmx:mdrun`` from
+    Gromacs 5.x but just ``mdrun`` for Gromacs 4.6.x. Similarly, alternative
+    executables (such as double precision) need to be specified here
+    (e.g. ``("mdrun_d", "gmx_d:mdrun")``).
+
+    .. Note:: Changing :program:`mdrun` arguments permanently changes the
+              default arguments for this instance of :class:`MDrunner`. (This
+              is arguably a bug.)
+
+    .. versionchanged:: 0.5.1
+       Added detection of bare Gromacs commands (Gromacs 4.6.x) or commands run through
+       :program:`gmx` (Gromacs 5.x).
+
     """
 
-    #: path to the :program:`mdrun` executable (or the name if it can be found on :envvar:`PATH`)
-    mdrun = "mdrun"
+    #: Path to the :program:`mdrun` executable (or the name if it can be found on :envvar:`PATH`);
+    #: this can be a tuple and then the program names are tried in sequence. You can use
+    #: the syntax from the config file ``gmx:mdrun`` to designate a driver command.
+    #:
+    #: .. versionadded:: 0.5.1
+    mdrun = ("mdrun", "gmx:mdrun")
     #: path to the MPI launcher (e.g. :program:`mpiexec`)
     mpiexec = None
 
@@ -80,11 +136,14 @@ class MDrunner(utilities.FileUtils):
         """
         # run MD in this directory (input files must be relative to this dir!)
         self.dirname = dirname
+        self.driver, self.name = find_gromacs_command(self.mdrun)
 
         # use a GromacsCommand class for handling arguments
         cls = type('MDRUN', (core.GromacsCommand,),
-                   {'command_name': self.mdrun,
-                    '__doc__': "MDRUN command %r" % self.mdrun})
+                   {'command_name': self.name,
+                    'driver': self.driver,
+                    '__doc__': "MDRUN command {0} {1}".format(self.driver, self.name)
+                   })
 
         kwargs['failure'] = 'raise'    # failure mode of class
         self.MDRUN = cls(**kwargs)  # might fail for mpi binaries? .. -h?
@@ -219,24 +278,15 @@ class MDrunner(utilities.FileUtils):
         return check_mdrun_success(self.logname)
 
 class MDrunnerDoublePrecision(MDrunner):
-    """Manage running :program:`mdrun_d`.
-    """
-    mdrun = "mdrun_d"
+    """Manage running :program:`mdrun_d`."""
+    mdrun = ("mdrun_d", "gmx_d:mdrun")
 
 class MDrunnerOpenMP(MDrunner):
     """Manage running :program:`mdrun` as an OpenMP_ multiprocessor job.
 
     .. _OpenMP: http://openmp.org/wp/
     """
-    mdrun = "mdrun_openmp"
-    mpiexec = "mpiexec"
-
-class MDrunnerOpenMP64(MDrunner):
-    """Manage running :program:`mdrun` as an OpenMP_ multiprocessor job (64-bit executable).
-
-    .. _OpenMP: http://openmp.org/wp/
-    """
-    mdrun = "mdrun_openmp64"
+    mdrun = ("mdrun_openmp", "gmx_openmp:mdrun")
     mpiexec = "mpiexec"
 
 class MDrunnerMpich2Smpd(MDrunner):

--- a/gromacs/tests/test_run.py
+++ b/gromacs/tests/test_run.py
@@ -32,5 +32,17 @@ class Test_check_mdrun_success(TestCase):
     def test_incomplete_Gromacs5():
         assert(gromacs.run.check_mdrun_success(datafile('gromacs5_incomplete.log')) is False)
 
+# The following tests need an existing Gromacs environment. They should run
+# with either Gromacs 4 or Gromacs 5
+
+def test_MDRunner():
+    try:
+        mdrun = gromacs.run.MDrunner()
+    except OSError:
+        raise RuntimeError("This test requires a Gromacs environment.")
+
+    rc = mdrun.run(mdrunargs={'version': True})
+    assert(rc == 0)
+
 
 

--- a/gromacs/tests/test_utilities.py
+++ b/gromacs/tests/test_utilities.py
@@ -1,0 +1,17 @@
+# GromacsWrapper: test_example.py
+# Copyright (c) 2009 Oliver Beckstein <orbeckst@gmail.com>
+# Released under the GNU Public License 3 (or higher, your choice)
+# See the file COPYING for details.
+
+from __future__ import division, absolute_import, print_function
+
+import os.path
+
+import gromacs.utilities
+
+
+def test_which(name="cat"):
+    path = gromacs.utilities.which(name)
+    assert(os.path.basename(gromacs.utilities.which("cat")), name)
+
+

--- a/gromacs/tools.py
+++ b/gromacs/tools.py
@@ -106,35 +106,37 @@ aliases5to4 = {
 for name in sorted(config.load_tools):
     # compatibility for 5.x 'gmx toolname': add as gmx:toolname
     if name.find(':') != -1:
+        # Gromacs 5
         b_gmx5 = True
         prefix = name.split(':')[0]
         name = name.split(':')[1]
         #make alias for backwards compatibility
-        
+
         #the common case of just dropping the 'g_'
         old_name = 'g_' + name
 
         #check against uncommon name changes
-        #have to check each one, since it's possible there are suffixes like for double precision        
+        #have to check each one, since it's possible there are suffixes like for double precision
         for c5, c4 in aliases5to4.iteritems():
             if name.startswith(c5):
                 #maintain suffix
                 old_name = c4 + name.split(c5)[1]
                 break
-            
+
         # make names valid python identifiers and use convention that class names are capitalized
         clsname = name.replace('.','_').replace('-','_').capitalize()
         old_clsname = old_name.replace('.','_').replace('-','_').capitalize()
-        cls = type(clsname, (GromacsCommand,), {'command_name':name,
-                                                   'driver':prefix,
-                                                   '__doc__': "Gromacs tool '%(prefix) %(name)r'." % vars()})
+        cls = type(clsname, (GromacsCommand,), {'command_name': name,
+                                                'driver' :prefix,
+                                                '__doc__': "Gromacs tool '%(prefix) %(name)r'." % vars()})
         #add alias for old name
         #No need to see if old_name == name since we'll just clobber the item in registry
         registry[old_clsname] = cls
     else:
+        # Gromacs 4:
         # make names valid python identifiers and use convention that class names are capitalized
         clsname = name.replace('.','_').replace('-','_').capitalize()
-        cls = type(clsname, (GromacsCommand,), {'command_name':name,
+        cls = type(clsname, (GromacsCommand,), {'command_name': name,
                                                 '__doc__': "Gromacs tool %(name)r." % vars()})
     registry[clsname] = cls      # registry keeps track of all classes
     # dynamically build the module doc string

--- a/gromacs/utilities.py
+++ b/gromacs/utilities.py
@@ -49,6 +49,7 @@ directories:
 
 .. autofunction:: find_first
 .. autofunction:: withextsep
+.. autofunction:: which
 
 Functions that improve list processing and which do *not* treat
 strings as lists:
@@ -339,6 +340,28 @@ def find_files(directory, pattern):
                 filename = os.path.join(root, basename)
                 yield filename
 
+def which(program):
+    """Determine full path of executable *program* on :envvar:`PATH`.
+
+    (Jay at http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python)
+
+    .. versionadded:: 0.5.1
+    """
+
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        real_program = realpath(program)
+        if is_exe(real_program):
+            return real_program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+    return None
 
 class FileUtils(object):
     """Mixin class to provide additional file-related capabilities."""


### PR DESCRIPTION
- fixes #64
- added a hack whereby multiple commands can be supplied in the MDRunner.mdrun
  attribute: the new run.find_gromacs_command() function tries them in order
  and takes the first one that seems to work
- added utilities.which() + test