### PR TITLE
Show the solution only once

### DIFF
--- a/gromacs/config.py
+++ b/gromacs/config.py
@@ -669,21 +669,24 @@ def check_setup():
          return True
 
      is_complete = True
+     show_solution = False
+
      if not os.path.exists(CONFIGNAME):
           is_complete = False
-          print "NOTE: The global configuration file %(CONFIGNAME)r is missing." % globals()
-          print "      You can create a basic configuration file from within python:"
-          print "      >>> import gromacs"
-          print "      >>> gromacs.config.setup()"
+          show_solution = True
+          print("NOTE: The global configuration file %r is missing." % CONFIGNAME)
 
      missing = [d for d in config_directories if not os.path.exists(d)]
      if len(missing) > 0:
           is_complete = False
-          print "NOTE: Some configuration directories are not set up yet"
-          print "      %r" % missing
-          print "      You can create them with the command from within Python"
-          print "      >>> import gromacs"
-          print "      >>> gromacs.config.setup()"
+          show_solution = True
+          print("NOTE: Some configuration directories are not set up yet: ")
+          print("\t%s" % '\n\t'.join(missing))
+
+     if show_solution:
+          print("NOTE: You can create the configuration file and directories with:")
+          print("\t>>> import gromacs")
+          print("\t>>> gromacs.config.setup()")
      return is_complete
 
 check_setup()


### PR DESCRIPTION
The solution for missing files and directories appears twice.

```
NOTE: The global configuration file '/home/peu/.gromacswrapper.cfg' is missing.
      You can create a basic configuration file from within python:
      >>> import gromacs
      >>> gromacs.config.setup()
NOTE: Some configuration directories are not set up yet
      ['/home/peu/.gromacswrapper', '/home/peu/.gromacswrapper/qscripts', '/home/peu/.gromacswrapper/templates', '/home/peu/.gromacswrapper/managers']
      You can create them with the command from within Python
      >>> import gromacs
      >>> gromacs.config.setup()
```

With this commit it appears only once:

```
NOTE: The global configuration file '/home/peu/.gromacswrapper.cfg' is missing.
NOTE: Some configuration directories are not set up yet: 
	/home/peu/.gromacswrapper
	/home/peu/.gromacswrapper/qscripts
	/home/peu/.gromacswrapper/templates
	/home/peu/.gromacswrapper/managers
NOTE: You can create the configuration file and directories with:
	>>> import gromacs
	>>> gromacs.config.setup()
```