### PR TITLE
fixed find_gromacs_command()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
 
 # run tests
 script: 
-  - py.test --cov gromacs
+  - py.test --cov gromacs gromacs/tests
 
 after_success:
   - codecov

--- a/gromacs/run.py
+++ b/gromacs/run.py
@@ -55,17 +55,16 @@ def find_gromacs_command(commands):
     # We could try executing 'name' or 'driver name' but to keep things lean we
     # just check if the executables can be found and then hope for the best.
 
-    for command in utilities.asiterable(commands):
-        if command.find(':') != -1:
-            driver = command.split(':')[0]
-            name = command.split(':')[1]
-            if utilities.which(driver):
-                break
-        else:
-            driver = None
-            name = command
-            if utilities.which(name):
-                break
+    commands = utilities.asiterable(commands)
+    for command in commands:
+        try:
+            driver, name = command.split()
+        except ValueError:
+            driver, name = None, command
+
+        executable = driver if driver else name
+        if utilities.which(executable):
+            break
     else:
         raise OSError(errno.ENOENT, "No Gromacs executable found in", ", ".join(commands))
 

--- a/gromacs/tests/fileformats/top/top.py
+++ b/gromacs/tests/fileformats/top/top.py
@@ -10,6 +10,8 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_
 from pandas.util.testing import assert_frame_equal
 
+import pytest
+
 import gromacs
 from gromacs.fileformats import TOP, XVG
 from gromacs.scaling import partial_tempering
@@ -54,7 +56,7 @@ class Namespace(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
-
+@pytest.mark.skip(reason="Not currently maintained. See #61.")
 class TopologyTest(object):
         grompp = 'fileformats/top/grompp.mdp'
         def test_basic(self):

--- a/gromacs/tests/test_run.py
+++ b/gromacs/tests/test_run.py
@@ -5,6 +5,7 @@
 
 from __future__ import division, absolute_import, print_function
 
+import pytest
 from unittest import TestCase
 
 from .datafiles import datafile
@@ -44,5 +45,20 @@ def test_MDRunner():
     rc = mdrun.run(mdrunargs={'version': True})
     assert(rc == 0)
 
+class Test_find_gromacs_command(TestCase):
+    # Gromacs 4 or Gromacs 5 (in this order)
+    commands = ["grompp", "gmx grompp"]
 
+    def test_find(self):
+        driver, name = gromacs.run.find_gromacs_command(self.commands)
+        assert (driver in (None, "gmx"),
+               "find_gromacs_command() did not identify a driver")
+        assert (name == self.commands[0],
+               "find_gromacs_command() did not find a command")
+
+
+    @staticmethod
+    def test_raises_ValueError():
+        with pytest.raises(OSError):
+            driver, name = gromacs.run.find_gromacs_command(["./not_a_command"])
 


### PR DESCRIPTION
- run.find_gromacs_command() was still using the old gmx:mdrun driver/command syntax
- fixes #85 