### PR TITLE
Gromacs 2018 and pytest low-performance custom plugin to control -nt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,6 @@ matrix:
 install:
   - git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
-  # install test tools (explicit instead of PIP_DEPENDENCIES because
-  # this is temporary until #137 is solved)
-  - pip install git+git://github.com/ianmkenney/pytest-gmx.git  
   - eval $BUILD_CMD
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: GROMACS_VERSION=2018.2  PYTHON_VERSION=2.7 CODECOV=false
     - env: GROMACS_VERSION=2018.2  PYTHON_VERSION=3.6 CODECOV=false
     - env: GROMACS_VERSION=4.6.5   PYTHON_VERSION=3.6
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - PYTHON_VERSION=2.7
     - CODECOV=true
-    - PYTEST_FLAGS="-v --disable-pytest-warnings --durations=20 --low-performance"
+    - PYTEST_FLAGS="-v --disable-pytest-warnings --durations=20 --low-performance --cov=gromacs"
     - PYTEST_LIST="gromacs/tests"
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"
@@ -27,17 +27,21 @@ env:
 
   matrix:
     # use ci-helper's PACKAGENAME_VERSION magic to pin the 'gromacs' package
-    - GROMACS_VERSION=4.6.5   PYTHON_VERSION=2.7 SETUP_CMD="${PYTEST_FLAGS} --cov=gromacs"
-    - GROMACS_VERSION=2018.2  PYTHON_VERSION=2.7 SETUP_CMD="${PYTEST_FLAGS} --cov=gromacs"
-    - GROMACS_VERSION=4.6.5   PYTHON_VERSION=3.6 SETUP_CMD="${PYTEST_FLAGS} --cov=gromacs"
-    - GROMACS_VERSION=2018.2  PYTHON_VERSION=3.6 SETUP_CMD="${PYTEST_FLAGS} --cov=gromacs"
+    - GROMACS_VERSION=4.6.5   PYTHON_VERSION=2.7
+    - GROMACS_VERSION=2018.2  PYTHON_VERSION=2.7 CODECOV=false
+    - GROMACS_VERSION=4.6.5   PYTHON_VERSION=3.6
+    - GROMACS_VERSION=2018.2  PYTHON_VERSION=3.6 CODECOV=false
 
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: GROMACS_VERSION=2018.2 PYTHON_VERSION=2.7
-    - env: GROMACS_VERSION=2018.2 PYTHON_VERSION=3.6
+    - env: GROMACS_VERSION=2018.2  PYTHON_VERSION=2.7 CODECOV=false
+    - env: GROMACS_VERSION=2018.2  PYTHON_VERSION=3.6 CODECOV=false
+    - env: GROMACS_VERSION=4.6.5   PYTHON_VERSION=3.6
+    - os: osx
+      env: GROMACS_VERSION=4.6.5 PYTHON_VERSION=3.6
+
 
   include:
     # note: no OSX Gromacs 2018 packages on bioconda https://anaconda.org/bioconda/gromacs/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - PYTHON_VERSION=2.7
     - CODECOV=true
-    - PYTEST_FLAGS="-v --disable-pytest-warnings --durations=20"
+    - PYTEST_FLAGS="-v --disable-pytest-warnings --durations=20 --low-performance"
     - PYTEST_LIST="gromacs/tests"
     - MAIN_CMD="pytest ${PYTEST_LIST}"
     - SETUP_CMD="${PYTEST_FLAGS}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,10 @@ matrix:
 install:
   - git clone --depth 1 git://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
+  # install test tools (explicit instead of PIP_DEPENDENCIES because
+  # this is temporary until #137 is solved)
+  - pip install git+git://github.com/ianmkenney/pytest-gmx.git  
   - eval $BUILD_CMD
-
 
 script:
   - cd ${TRAVIS_BUILD_DIR}

--- a/CHANGES
+++ b/CHANGES
@@ -3,9 +3,10 @@
 ==============================
 
 2018-xx-xx      0.7.0
-orbeckst, kain88-de
+orbeckst, kain88-de, ianmkenney
 
 * support Python 3 (#44)
+* support Gromacs 2018 (and likely also Gromacs 2016) (#96)
 * moved numkit to own package now at
   https://github.com/Becksteinlab/numkit (#111)
 * removed gromacs.analysis legacy code, can now be found

--- a/gromacs/setup.py
+++ b/gromacs/setup.py
@@ -695,7 +695,7 @@ def energy_minimize(dirname='em', mdp=config.templates['em.mdp'],
     with in_dir(dirname):
         unprocessed = cbook.edit_mdp(mdp_template, new_mdp=mdp, **kwargs)
         check_mdpargs(unprocessed)
-        gromacs.grompp(f=mdp, o=tpr, c=structure, p=topology, **unprocessed)
+        gromacs.grompp(f=mdp, o=tpr, c=structure, r=structure, p=topology, **unprocessed)
         mdrun_args.update(v=True, stepout=10, deffnm=deffnm, c=output)
         if mdrunner is None:
             mdrun = run.get_double_or_single_prec_mdrun()

--- a/gromacs/tests/conftest.py
+++ b/gromacs/tests/conftest.py
@@ -19,6 +19,6 @@ def pytest_addoption(parser):
             help='Instruct Gromacs to run in low performance mode (as defined in tests)',
     )
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def low_performance(request):
     return request.config.option.low_performance

--- a/gromacs/tests/conftest.py
+++ b/gromacs/tests/conftest.py
@@ -1,0 +1,24 @@
+# GromacsWrapper: test_example.py
+# Copyright (c) 2009 Oliver Beckstein <orbeckst@gmail.com>
+# Released under the GNU Public License 3 (or higher, your choice)
+# See the file COPYING for details.
+
+# Ian Kenney's pytest-gmx plugin
+# https://github.com/ianmkenney/pytest-gmx/
+
+import pytest
+
+def pytest_addoption(parser):
+    """Add options to control Gromacs performance settings"""
+
+    group = parser.getgroup('gmx')
+    group.addoption(
+            "--low-performance",
+            action="store_true",
+            dest='low_performance',
+            help='Instruct Gromacs to run in low performance mode (as defined in tests)',
+    )
+
+@pytest.fixture
+def low_performance(request):
+    return request.config.option.low_performance

--- a/gromacs/tests/fileformats/top/test_amber03star.py
+++ b/gromacs/tests/fileformats/top/test_amber03star.py
@@ -16,9 +16,3 @@ class TestAmber03star(TopologyTest):
         processed = datafile('fileformats/top/amber03star/processed.top')
         conf = datafile('fileformats/top/amber03star/conf.gro')
         molecules = ['Protein', 'SOL', 'IB+', 'CA', 'CL', 'NA', 'MG', 'K', 'RB', 'CS', 'LI', 'ZN']
-
-        def test_read_write(self, tmpdir):
-                super(TestAmber03star, self).test_read_write(tmpdir)
-
-        def test_mdrun(self, tmpdir):
-                super(TestAmber03star, self).test_mdrun(tmpdir)

--- a/gromacs/tests/fileformats/top/test_amber03w.py
+++ b/gromacs/tests/fileformats/top/test_amber03w.py
@@ -16,12 +16,3 @@ class TestAmber03w(TopologyTest):
         processed = datafile('fileformats/top/amber03w/processed.top')
         conf = datafile('fileformats/top/amber03w/conf.gro')
         molecules = ['Protein_chain_A', 'SOL', 'IB+', 'CA', 'CL', 'NA', 'MG', 'K', 'RB', 'CS', 'LI', 'ZN']
-
-        def test_read_write(self, tmpdir):
-                super(TestAmber03w, self).test_read_write(tmpdir)
-
-        def test_grompp(self, tmpdir):
-                super(TestAmber03w, self).test_grompp(tmpdir)
-
-        def test_mdrun(self, tmpdir):
-                super(TestAmber03w, self).test_mdrun(tmpdir)

--- a/gromacs/tests/fileformats/top/test_charmm22.py
+++ b/gromacs/tests/fileformats/top/test_charmm22.py
@@ -14,6 +14,3 @@ class TestCharmm22st(TopologyTest):
         processed = datafile('fileformats/top/charmm22st/processed.top')
         conf = datafile('fileformats/top/charmm22st/conf.gro')
         molecules = ['SOL', 'Protein', 'Ion', 'Cal', 'Ces', 'CL', 'K', 'NA', 'ZN']
-
-        def test_read_write(self, tmpdir):
-                super(TestCharmm22st, self).test_read_write(tmpdir)

--- a/gromacs/tests/fileformats/top/top.py
+++ b/gromacs/tests/fileformats/top/top.py
@@ -38,7 +38,7 @@ def grompp(f, c, p, prefix="topol"):
 
 def mdrun(s, prefix):
         o = prefix + '.trr'
-        rc, output, junk = gromacs.mdrun(v=True, s=s, o=o, stdout=False, stderr=False)
+        rc, output, junk = gromacs.mdrun(v=True, s=s, o=o, stdout=False, stderr=False, nt=2)
         assert rc == 0, "mdrun failed"
         return o
 

--- a/gromacs/tests/fileformats/top/top.py
+++ b/gromacs/tests/fileformats/top/top.py
@@ -155,6 +155,11 @@ class TopologyTest(object):
 
         def test_mdrun(self, tmpdir, low_performance):
                 """Check if grompp can be run successfully at all"""
+                # set low_performance with
+                #
+                #    pytest --low-performance
+                #
+                # (needs plugin https://github.com/ianmkenney/pytest-gmx)
                 f = self.mdp
                 c = self.conf
                 processed = self.processed

--- a/gromacs/tests/fileformats/top/top.py
+++ b/gromacs/tests/fileformats/top/top.py
@@ -20,18 +20,20 @@ from gromacs.scaling import partial_tempering
 
 from ...datafiles import datafile
 
-def helper(attr, attr1, attr2):
-        print(attr)
+def errmsg_helper(attr, attr1, attr2):
+        msg = ["attr = " + str(attr)]
         for pair in zip(attr1, attr2):
-                if pair[0] == pair[1]: continue
-                print(pair)
+                if pair[0] == pair[1]:
+                        continue
+                msg.append(str(pair))
+        return "\n".join(msg)
 
-def grompp(f, c, p, prefix="topol"):
+def grompp(f, c, p, prefix="topol", **kwargs):
         s = prefix + '.tpr'
         po = prefix + '.mdp'
 
-        rc, output, junk = gromacs.grompp(f=f, p=p, c=c, o=s, po=po, stdout=False, stderr=False)
-        #print(rc, output, junk)
+        rc, output, junk = gromacs.grompp(f=f, p=p, c=c, o=s, po=po, stdout=False, stderr=False,
+                                          **kwargs)
         assert rc == 0, \
                 "grompp -o {0} -po {1} -f {2} -c {3} -p {4} failed".format(s, po, f, c, p)
         return s
@@ -140,7 +142,7 @@ class TopologyTest(object):
                         for attr in attrs1:
                                 attr1 = getattr(top1, attr)
                                 attr2 = getattr(top2, attr)
-                                assert attr1 == attr2, helper(attr, attr1, attr2)
+                                assert attr1 == attr2, errmsg_helper(attr, attr1, attr2)
 
         def test_grompp(self, tmpdir):
                 """Check if grompp can be run successfully at all"""
@@ -157,17 +159,13 @@ class TopologyTest(object):
                 """Check if grompp can be run successfully at all"""
                 # set low_performance with
                 #
-                #    pytest --low-performance
+                #    pytest --low-performance gromacs/tests
                 #
-                # (needs plugin https://github.com/ianmkenney/pytest-gmx)
                 f = self.mdp
                 c = self.conf
                 processed = self.processed
 
-                if low_performance:
-                    nt = 2
-                else:
-                    nt = 0
+                nt = 2 if low_performance else 0
 
                 with tmpdir.as_cwd():
                         tpr = grompp(f, c, processed, prefix="reference")
@@ -190,7 +188,7 @@ class TopologyTest(object):
                         args = Namespace(banned_lines='', input=processed,
                                          output=scaled, scale_lipids=1.0, scale_protein=0.5)
                         partial_tempering(args)
-                        tpr = grompp(f, c, scaled, prefix="scaled")
+                        tpr = grompp(f, c, scaled, prefix="scaled", maxwarn=1)
                         df3 = rerun_energy(tpr, reference_trr, prefix="scaled", nt=nt)
                         # print(df1, df1.columns)
                         # print(df3, df3.columns)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,16 @@ setup(name="GromacsWrapper",
                           'six',          # towards py 3 compatibility
                           'numkit',       # numerical helpers
                           ],
+      # also currently requires
+      #
+      #    pip install git+git://github.com/ianmkenney/pytest-gmx.git
+      #
+      # for the low_performance pytest fixture: allows running
+      #
+      #    pytest --low-performance
+      #
+      # so that test are run with 'gmx mdrun -nt 2' as necessary on travis
+      # (instead of the maximum number of threads, as determined by Gromacs)
       tests_require = ['pytest', 'numpy>=1.0', 'pandas>=0.17'],
       zip_safe = True,
 )

--- a/setup.py
+++ b/setup.py
@@ -55,16 +55,6 @@ setup(name="GromacsWrapper",
                           'six',          # towards py 3 compatibility
                           'numkit',       # numerical helpers
                           ],
-      # also currently requires
-      #
-      #    pip install git+git://github.com/ianmkenney/pytest-gmx.git
-      #
-      # for the low_performance pytest fixture: allows running
-      #
-      #    pytest --low-performance
-      #
-      # so that test are run with 'gmx mdrun -nt 2' as necessary on travis
-      # (instead of the maximum number of threads, as determined by Gromacs)
       tests_require = ['pytest', 'numpy>=1.0', 'pandas>=0.17'],
       zip_safe = True,
 )


### PR DESCRIPTION
~Include Gromacs 2016 in tests (fixes #96)~

EDIT: We use Gromacs 2018 (see PR #127 and discussion in #130 ). This PR contains experimental pytest plugin to provide the `pytest --low-performance` flag and code to explicitly set the number of threads for `gmx mdrun` in the tests.