### PR TITLE
Listconversion for MDP files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,5 +43,10 @@ year of their first commit. GitHub handle is optional.
 - Mohamad Mohebifar (@mohebifar)
 
 
+2017
+----
+
+- Philip Loche (@PicoCentauri)
+
 We gratefully acknowledge code fixes contributed by
 @quantifiedcode-bot from Quantified Code https://www.quantifiedcode.com

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ mohebifar
 
 * fixed isnan test in ITPData._clean_records (#99)
 * fixed formatting replacement for molecule name in ITP moleculetype section (#98)
+* conversion for lists in Gromacs mdp files added (#104)
 
 2016-09-16      0.6.1
 orbeckst, quantifiedcode-bot
@@ -34,7 +35,7 @@ whitead, dotsdl, orbeckst
 
 * fixed: check_mdrun_success() works now for Gromacs 4 and Gromacs 5
   (issue #64)
-* fixed: MDRunner working for Gromacs 4 and Gromacs 5 (issue #64)  
+* fixed: MDRunner working for Gromacs 4 and Gromacs 5 (issue #64)
 * fixed setup.energy_minimize() not falling back to single precision
   mdrun (issue #63)
 * fixed: added missing alias "gmx solvate" <--> "genbox" (issue #62)
@@ -54,7 +55,7 @@ quantifiedcode-bot, orbeckst, jandom, whitead
   installation issues (#40)
 * Allows custom prefixes like gmx_mpi:mdrun and gmx:trjconv (#48)
 * Made it so GromacsWrapper can be imported and tools loaded even if they can't
-  be executed at import time. 
+  be executed at import time.
 
 2015-12-16      0.4.0
 orbeckst, richardjgowers
@@ -71,7 +72,7 @@ orbeckst, jandom
 * additional logging of filenames in setup._MD()
 * new repository URL: https://github.com/Becksteinlab/GromacsWrapper
 
-2013-08-07     0.3.2  
+2013-08-07     0.3.2
 orbeckst, andy.somogyi
 
 * fixed setup.make_main_index() by using a workaround for a bug in make_ndx
@@ -80,7 +81,7 @@ orbeckst, andy.somogyi
   write output to specified directory)
 * gw-fit_strip_trajectories.py: can use a custom group for centering
   (necessary when dealing with multimeric proteins that might get
-  split across the periodic boundaries)  
+  split across the periodic boundaries)
 
 
 2012-12-10     0.3.1
@@ -90,7 +91,7 @@ orbeckst, jandom
 * new HBonds hydrogen bonding analysis plugin (uses g_hbond and can
   return individual hbond existence probabilities)
 * XVG has initial support to plot periodic data such as dihedral angles
-* ITP reader: 
+* ITP reader:
   - ITP.contains_preprocessor_constructs() to check if the
     itp file uses some of the recognized preprocessing directives
   - new set_data() method to completely rebuild a topology
@@ -101,7 +102,7 @@ orbeckst, jandom
   - gw-fit_strip_trajectories.py: remove water and fit to protein
   - gw-join_parts.py: concatenate xtc, trr, edr, log for simulations
     done in parts (and with -noappend)
-  - gw-merge_topologies.py: join multiple building block topologies 
+  - gw-merge_topologies.py: join multiple building block topologies
 * updated MDP templates
   - increase Parrinello-Rahman time constant to 1.0 ps
   - use refcoord_scaling = "com" for position restraints
@@ -114,7 +115,7 @@ orbeckst, jandom
   - bt takes precedence over boxtype
 
 
-2012-04-24     0.3.0   
+2012-04-24     0.3.0
 orbeckst
 
 * improved file format handling (ITP (incomplete, but uses a

--- a/gromacs/fileformats/mdp.py
+++ b/gromacs/fileformats/mdp.py
@@ -154,5 +154,7 @@ class MDP(odict, utilities.FileUtils):
                 else:                  # parameter = value
                     if skipempty and (v == '' or v is None):
                         continue
-                    mdp.write("{k!s} = {v!s}\n".format(**vars()))
-
+                    if hasattr(v, '__iter__'):
+                         mdp.write("{} = {}\n".format(k,' '.join(map(str, v))))
+                    else:
+                        mdp.write("{k!s} = {v!s}\n".format(**vars()))

--- a/gromacs/tests/test_utilities.py
+++ b/gromacs/tests/test_utilities.py
@@ -10,6 +10,8 @@ import pytest
 from six.moves import cPickle as pickle
 from six.moves import StringIO
 
+import numpy
+
 import gromacs.utilities
 
 @pytest.fixture
@@ -60,10 +62,14 @@ class TestAttributeDict(object):
         assert set(d.values()) == set(self.d.values())
 
 
-@pytest.fixture(params=[(42, int), ("42", int), (2.7, float), ("2.7", float),
-                        ("jabberwock", str)],
-                ids=["int -> int", "str -> int", "float -> float", "str -> float",
-                     "str -> str"])
+@pytest.fixture(params=[(42, int),("42", int), ([42],int) ,
+                        (2.7, float), ("2.7", float), ([2.7],float),
+                        ("jabberwock", str),(["foo","bar"], str),
+                        ("42 42",int),("2.7 2.7",float),("foo bar",str)],
+                ids=["int -> int", "str -> int","int list -> int list",
+                     "float -> float", "str -> float", "float list -> float list",
+                     "str -> str","str list -> str list",
+                     "str -> int list","str -> float list","str -> str list"])
 def conversions(request):
     value, target_type = request.param
     x = gromacs.utilities.autoconvert(value)
@@ -71,6 +77,7 @@ def conversions(request):
 
 def test_autoconvert(conversions):
     x, value, target_type = conversions
+    if hasattr(x, '__iter__'): x = x[0]
     assert isinstance(x, target_type), \
         "Failed to convert '{0}' to type {1}".format(value, target_type)
 
@@ -114,4 +121,3 @@ class TestOpenAny(object):
             # in MDAnalysis)
             # check inside with block
             assert data == self.quote
-

--- a/gromacs/utilities.py
+++ b/gromacs/utilities.py
@@ -98,6 +98,7 @@ import subprocess
 from contextlib import contextmanager
 import bz2, gzip
 import datetime
+import numpy
 
 import logging
 logger = logging.getLogger('gromacs.utilities')
@@ -134,8 +135,12 @@ def autoconvert(s):
         return s
     for converter in int, float, str:   # try them in increasing order of lenience
         try:
-            return converter(s)
-        except ValueError:
+            s = [converter(i) for i in s.split()]
+            if len(s) == 1:
+                return s[0]
+            else:
+                return numpy.array(s)
+        except (ValueError,AttributeError):
             pass
     raise ValueError("Failed to autoconvert {0!r}".format(s))
 


### PR DESCRIPTION
Lists in MDP files will be converted into numpy arrays if autoconvert=True is set.
This enhancement can be useful for changing list parameters in the mdp file i.e. lambda states.