### PR TITLE
explicitly set master branch as default for codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  branch: master
+


### PR DESCRIPTION
fix #156