### PR TITLE
 Added function for setting up FEP simulations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ running simulations with sensible parameters.
 .. |build| image:: https://travis-ci.org/Becksteinlab/GromacsWrapper.svg
    :target: https://travis-ci.org/Becksteinlab/GromacsWrapper
    :alt: Build Status
-.. |cov| image:: https://codecov.io/gh/Becksteinlab/GromacsWrapper/graph/badge.svg
+.. |cov| image:: https://codecov.io/gh/Becksteinlab/GromacsWrapper/badge.svg
    :target: https://codecov.io/gh/Becksteinlab/GromacsWrapper
    :alt: Code Coverage
    :scale: 100%

--- a/gromacs/setup.py
+++ b/gromacs/setup.py
@@ -35,7 +35,7 @@ sequence of functions that depend on the previous step(s):
         :func:`energy_minimize`)
   :func:`MD_restrained`
         set up restrained MD
-:func:`MD_restrained`
+  :func:`MD_restrained`
       set up free energy pertubation MD
   :func:`MD`
         set up equilibrium MD
@@ -1046,11 +1046,11 @@ def MD_fep(dirname='MD_FEP', stateprefix="lambda_", **kwargs):
 
     :Keywords:
        *dirname*
-          set up under directory dirname [MD_POSRES]
+          set up under directory dirname [MD_FEP]
        *stateprefix*
-          Folder prefix for the lambda state
+          Folder prefix for the lambda state [lambda_]
        *struct*
-          input structure (gro, pdb, ...) [em/em.pdb]
+          input structure (gro, pdb, ...) [conf.gro]
        *top*
           topology file [top/system.top]
        *mdp*
@@ -1066,12 +1066,6 @@ def MD_fep(dirname='MD_FEP', stateprefix="lambda_", **kwargs):
           *tau_t*, and *ref_t* as keyword arguments, or provide the mdp template
           with all parameter pre-set in *mdp* and probably also your own *ndx*
           index file.)
-       *deffnm*
-          default filename for Gromacs run [md]
-       *runtime*
-          total length of the simulation in ps [1000]
-       *dt*
-          integration time step in ps [0.002]
        *qscript*
           script to submit to the queuing system; by default
           uses the template :data:`gromacs.config.qscript_template`, which can
@@ -1098,13 +1092,16 @@ def MD_fep(dirname='MD_FEP', stateprefix="lambda_", **kwargs):
             except KeyError:
                 pass
     
-    nlambdas = nlambdas(fileformats.mdp.MDP(kwargs["mdp"]))
+    nlambdas = nlambdas(mdp.MDP(kwargs["mdp"]))
     logger.info("Create input folders and files for {} lambda states...".format(nlambdas))
     
-    with in_dir(dirname):
-        for l in range(nlambdas):
-            new_kwargs = _setup_MD("stateprefix{}".format(l), 
-                                   init_lambda_state=l, **kwargs)
+    kwargs.setdefault('struct', 'conf.gro')
+    
+    for l in range(nlambdas):
+        kwargs.setdefault('qname', 'MD_FEP_'.format(l))
+        new_kwargs = _setup_MD(dirname=os.path.join(dirname, stateprefix+str(l)), 
+                               init_lambda_state=l, 
+                               **kwargs)
             
     return new_kwargs
         


### PR DESCRIPTION
The function in the setup module allows to set up free energy pertubation simualtions. It will create a single simulation folder for all lambda states to run them individually.

In contrast to the other setup functions I used a dictionary input for the submission script, since I think its more convenient. 

Furthermore I wondered about two thinks: 

1. The setup functions seem not really consistent regarding their input parameters and their standard values between them: for example [energy_miniztion](https://github.com/Becksteinlab/GromacsWrapper/blob/d96c34f5d7d81175e823746322f2760c31447e81/gromacs/setup.py#L609-L655) and [MD](https://github.com/Becksteinlab/GromacsWrapper/blob/d96c34f5d7d81175e823746322f2760c31447e81/gromacs/setup.py#L1034-L1087). Maybe we should think about to unify those. 

2. Is there a reason that the [edit_mdp](https://github.com/Becksteinlab/GromacsWrapper/blob/d96c34f5d7d81175e823746322f2760c31447e81/gromacs/cbook.py#L778-L899) function is not using the mdp file format parser?