### PR TITLE
Support Slurm in gromacs.qsub

### DIFF
--- a/gromacs/qsub.py
+++ b/gromacs/qsub.py
@@ -367,12 +367,12 @@ def generate_submit_scripts(templates, prefix=None, deffnm='md', jobname='MD', b
         logger.info("Setting up queuing system script {submitscript!r}...".format(**vars()))
         # These substitution rules are documented for the user in the module doc string
         qsystem = detect_queuing_system(template)
-        if qsystem.name == 'Slurm':
+        if qsystem is not None and (qsystem.name == 'Slurm'):
             cbook.edit_txt(template,
                            [('^ *DEFFNM=','(?<==)(.*)', deffnm),
                             ('^#.*(-J)', '((?<=-J\s))\s*\w+', jobname),
                             ('^#.*(-A|account_no)', '((?<=-A\s)|(?<=account_no\s))\s*\w+', budget),
-                            ('^#.*(-t walltime)', '(?<==)(\d+:\d+:\d+)', walltime),
+                            ('^#.*(-t)', '(?<=-t\s)(\d+:\d+:\d+)', walltime),
                             ('^ *WALL_HOURS=', '(?<==)(.*)', wall_hours),
                             ('^ *STARTDIR=', '(?<==)(.*)', startdir),
                             ('^ *NPME=', '(?<==)(.*)', npme),

--- a/gromacs/tests/test_qsub.py
+++ b/gromacs/tests/test_qsub.py
@@ -3,7 +3,7 @@ import pytest
 
 import gromacs.qsub
 
-def test_queuing_systems(known=("Sun Gridengine", "PBS", "LoadLeveler")):
+def test_queuing_systems(known=("Sun Gridengine", "PBS", "LoadLeveler", 'Slurm')):
     assert len(gromacs.qsub.queuing_systems) == len(known)
     for qs in gromacs.qsub.queuing_systems:
         assert qs.name in known
@@ -18,7 +18,8 @@ def test_queuing_systems(known=("Sun Gridengine", "PBS", "LoadLeveler")):
 @pytest.mark.parametrize("scriptfile,name", [
     ("foo.sge", "Sun Gridengine"),
     ("foo.pbs", "PBS"),
-    ("foo.ll", "LoadLeveler")])
+    ("foo.ll", "LoadLeveler"),
+    ("foo.slu", "Slurm")])
 def test_detect_queuing_system(scriptfile, name):
     qs = gromacs.qsub.detect_queuing_system(scriptfile)
     assert qs.name == name


### PR DESCRIPTION
Current GromacsWrapper cannot edit slurm job script correctly due to the contradiction between slurm setting options and Sun Gridengine. 

Changes made in this Pull Request:
 - Add slurm as one option in qsub.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
