### PR TITLE
don't call `logger` directly, fix #173 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ richardjgowers, theavey, andrejberg, orbeckst
   (Issue #149)
 * fixed NDX writing (#152)
 * fixed Python 3 compatibility of XPM reader (PR #169)
+* fixed bug in calling logger in fileformats.top (issue #173)
 
 2018-08-08      0.7.0
 orbeckst, dldotson, kain88-de, ianmkenney

--- a/gromacs/fileformats/top.py
+++ b/gromacs/fileformats/top.py
@@ -234,7 +234,7 @@ class TOP(blocks.System):
 
                     '''
                     if len(fields) not in (6,7,8):
-                        self.logger('skipping atomtype line with neither 7 or 8 fields: \n {0:s}'.format(line))
+                        self.logger.warning('skipping atomtype line with neither 7 or 8 fields: \n {0:s}'.format(line))
                         continue
 
                     #shift = 0 if len(fields) == 7 else 1
@@ -249,7 +249,7 @@ class TOP(blocks.System):
                     particletype = fields[4+shift]
                     assert particletype in ('A', 'S', 'V', 'D')
                     if particletype not in ('A',):
-                        self.logger('warning: non-atom particletype: "{0:s}"'.format(line))
+                        self.logger.warning('warning: non-atom particletype: "{0:s}"'.format(line))
 
                     sig = float(fields[5+shift])
                     eps = float(fields[6+shift])


### PR DESCRIPTION
This should fix #173 because `logger` was called directly instead of, for example, `logger.debug` or `logger.warning`.

This should possibly be tested for, and it might be good to see if the same issue occurs other places (a search for `logger(` might be sufficient).