### PR TITLE
fix xvg plotting with matplotlib colors/cmaps

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@
  CHANGELOG for GromacsWrapper
 ==============================
 
-2020-xx-xx     0.8.1
+2021-xx-xx     0.8.1
 orbeckst, PolyachenkoYA, whitead 
 
 * fixed: core._run_command capture_output_file argument fixed to us python-3.0 
@@ -12,6 +12,8 @@ orbeckst, PolyachenkoYA, whitead
   'import gromacs' (PR #186)
 * fixed: xpm.to_df() used outdated convert_objects()
 * fixed: gw-forcefield.py use print() function for Py 2/3 compatibility
+* fixed: xvg.plot() and xvg.plot_coarsened() failed with Py 3 matplotlib
+  due to incompatible colors (issue #194)
 
 2019-04-30     0.8.0
 richardjgowers, theavey, andrejberg, orbeckst

--- a/gromacs/fileformats/xvg.py
+++ b/gromacs/fileformats/xvg.py
@@ -547,6 +547,14 @@ class XVG(utilities.FileUtils):
         """
         self.__array = numpy.asarray(a)
 
+    def _get_colors(self, color, columns):
+        try:
+            cmap = matplotlib.cm.get_cmap(color)
+            colors = cmap(matplotlib.colors.Normalize()(numpy.arange(len(columns[1:]), dtype=float)))
+        except (TypeError, ValueError):
+            colors = cycle(utilities.asiterable(color))
+        return colors
+
     def plot(self, **kwargs):
         """Plot xvg file data.
 
@@ -610,12 +618,7 @@ class XVG(utilities.FileUtils):
         else:
             a = self.array
 
-        color = kwargs.pop('color', self.default_color_cycle)
-        try:
-            cmap = matplotlib.cm.get_cmap(color)
-            colors = cmap(matplotlib.colors.Normalize()(numpy.arange(len(columns[1:]), dtype=float)))
-        except TypeError:
-            colors = cycle(utilities.asiterable(color))
+        colors = self._get_colors(kwargs.pop('color', self.default_color_cycle), columns)
 
         if ax is None:
             ax = plt.gca()
@@ -670,12 +673,7 @@ class XVG(utilities.FileUtils):
             raise MissingDataError("plot_coarsened() assumes that there is at least one column "
                                    "of data for the abscissa and one or more for the ordinate.")
 
-        color = kwargs.pop('color', self.default_color_cycle)
-        try:
-            cmap = matplotlib.cm.get_cmap(color)
-            colors = cmap(matplotlib.colors.Normalize()(numpy.arange(len(columns[1:]), dtype=float)))
-        except TypeError:
-            colors = cycle(utilities.asiterable(color))
+        colors = self._get_colors(kwargs.pop('color', self.default_color_cycle), columns)
 
         if ax is None:
             ax = plt.gca()


### PR DESCRIPTION
- fix #194
- made cmap/color cycle choice a private method _get_colors() and updated
  the exception the try/except clause to match modern matplotlib
- update CHANGES