### PR TITLE
use pandas.testing.assert_frame_equal

### DIFF
--- a/tests/fileformats/top/test_amber03star.py
+++ b/tests/fileformats/top/test_amber03star.py
@@ -12,9 +12,13 @@ import gromacs
 from .top import TopologyTest
 from ...datafiles import datafile
 
-@pytest.mark.xfail(gromacs.release().startswith("2022"),
-                   reason="issue https://github.com/Becksteinlab/GromacsWrapper/issues/236")
 class TestAmber03star(TopologyTest):
         processed = datafile('fileformats/top/amber03star/processed.top')
         conf = datafile('fileformats/top/amber03star/conf.gro')
         molecules = ['Protein', 'SOL', 'IB+', 'CA', 'CL', 'NA', 'MG', 'K', 'RB', 'CS', 'LI', 'ZN']
+
+        @pytest.mark.xfail(gromacs.release().startswith(("2022", "2023")),
+                           reason="issue #236 https://github.com/Becksteinlab/GromacsWrapper/issues/236")
+        def test_mdrun(self, tmpdir, low_performance):
+                super(TestAmber03star, self).test_mdrun(tmpdir, low_performance)
+

--- a/tests/fileformats/top/test_amber03w.py
+++ b/tests/fileformats/top/test_amber03w.py
@@ -12,9 +12,12 @@ import gromacs
 from .top import TopologyTest
 from ...datafiles import datafile
 
-@pytest.mark.xfail(gromacs.release().startswith("2022"),
-                   reason="issue https://github.com/Becksteinlab/GromacsWrapper/issues/236")
 class TestAmber03w(TopologyTest):
         processed = datafile('fileformats/top/amber03w/processed.top')
         conf = datafile('fileformats/top/amber03w/conf.gro')
         molecules = ['Protein_chain_A', 'SOL', 'IB+', 'CA', 'CL', 'NA', 'MG', 'K', 'RB', 'CS', 'LI', 'ZN']
+
+        @pytest.mark.xfail(gromacs.release().startswith(("2022", "2023")),
+                           reason="issue #236 https://github.com/Becksteinlab/GromacsWrapper/issues/236")
+        def test_mdrun(self, tmpdir, low_performance):
+                super(TestAmber03w, self).test_mdrun(tmpdir, low_performance)

--- a/tests/fileformats/top/top.py
+++ b/tests/fileformats/top/top.py
@@ -10,7 +10,12 @@ import os.path
 import numpy as np
 
 from numpy.testing import assert_array_equal
-from pandas.util.testing import assert_frame_equal
+
+try:
+        from pandas.testing import assert_frame_equal
+except ImportError:
+        # old versions of pandas
+        from pandas.util.testing import assert_frame_equal
 
 import pytest
 


### PR DESCRIPTION
- fix #248 
- use pandas.testing.assert_frame_equal
- XFAIL topology scaling tests for GROMACS >= 2022 (#236)