### PR TITLE
modernized CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
            channels:
               - conda-forge
               - bioconda
-           channel_priority: flexible
+           channel_priority: flexible	      
         cache-downloads: true
         cache-environment: true
         create-args: >-
@@ -98,7 +98,7 @@ jobs:
 
     - name: Install GROMACS (${{ matrix.gromacs-version }})
       run: |
-         micromamba install 'gromacs==${{ matrix.gromacs-version }}' pocl
+         micromamba install --py-pin 'gromacs==${{ matrix.gromacs-version }}' pocl
 
     - name: Install package (with no dependencies)
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
         cache-downloads: true
         cache-environment: true
         create-args: >-
-           python=${{ matrix.python-version }}
+           python=${{ matrix.python-version }}.*=*_cpython
 
     - name: Python version information ${{ matrix.python-version }}
       run: |
@@ -97,8 +97,12 @@ jobs:
          micromamba install pytest pytest-pep8 pytest-cov codecov
 
     - name: Install GROMACS (${{ matrix.gromacs-version }})
+      # UGLY HACK/FIX (probably to issues with bioconda packages)
+      # - For 3.9, micromamba insists on using pypy 3.9 (and --py-pin does not help).
+      # - For 2.7 macOS, numkit would get uninstalled.
+      # We can't freeze because then it's not possible to install older GROMACS versions from bioconda. 
       run: |
-         micromamba install --py-pin 'gromacs==${{ matrix.gromacs-version }}' pocl
+         micromamba install 'gromacs==${{ matrix.gromacs-version }}' pocl numkit python=${{ matrix.python-version }}.*=*_cpython
 
     - name: Install package (with no dependencies)
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,10 @@ concurrency:
   group: "${{ github.ref }}-${{ github.head_ref }}"
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -65,57 +69,49 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: setup miniconda (Python ${{ matrix.python-version }})
-      uses: conda-incubator/setup-miniconda@v2
+    - name: micromamba environment and package installation (Python ${{ matrix.python-version }})
+      uses: mamba-org/setup-micromamba@v1
       with:
-        python-version: ${{ matrix.python-version }}
-        auto-update-conda: true
-        mamba-version: "*"
-        channels: conda-forge,bioconda,defaults
-        channel-priority: true
-        show-channel-urls: true
-          
-    - name: Conda info
-      shell: bash -l {0}
-      run: |
-         conda info
-         conda list
-         conda config --show-sources
-         conda config --show
+        environment-file: ci/conda-envs/test_env.yaml
+        condarc: |
+           channels:
+              - conda-forge
+              - bioconda
+           channel_priority: flexible
+        cache-downloads: true
+        cache-environment: true
+        create-args: >-
+           python=${{ matrix.python-version }}
 
-    - name: Python version ${{ matrix.python-version }}
-      shell: bash -l {0}
+    - name: Python version information ${{ matrix.python-version }}
       run: |
          python -c "import sys; print(sys.version)"                
 
-    - name: Install package dependencies
-      shell: bash -l {0}
+    - name: micromamba environment information
       run: |
-         mamba install six numpy scipy matplotlib-base pandas numkit
+         micromamba info
+         micromamba list
 
     - name: Install pytest and plugins
-      shell: bash -l {0}
       run: |
-         mamba install pytest pytest-pep8 pytest-cov codecov
+         micromamba install pytest pytest-pep8 pytest-cov codecov
 
     - name: Install GROMACS (${{ matrix.gromacs-version }})
-      shell: bash -l {0}
       run: |
-         mamba install 'gromacs==${{ matrix.gromacs-version }}' pocl
+         micromamba install 'gromacs==${{ matrix.gromacs-version }}' pocl
 
-    - name: Install package
-      shell: bash -l {0}
+    - name: Install package (with no dependencies)
       run: |
         python -m pip install --no-deps .
 
     - name: Run tests
-      shell: bash -l {0}
       run: |
         pytest -v --disable-pytest-warnings --durations=20 --low-performance --cov=gromacs --cov-report=xml --color=yes ./tests
 
     - name: Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         file: ./coverage.xml
         fail_ci_if_error: false

--- a/ci/conda-envs/test_env.yaml
+++ b/ci/conda-envs/test_env.yaml
@@ -1,0 +1,12 @@
+name: test
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- python
+- six
+- numpy
+- scipy
+- matplotlib-base
+- pandas
+- numkit

--- a/ci/conda-envs/test_env.yaml
+++ b/ci/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
 - conda-forge
-- bioconda
 dependencies:
 - python
 - six

--- a/ci/conda-envs/test_env.yaml
+++ b/ci/conda-envs/test_env.yaml
@@ -5,8 +5,7 @@ channels:
 dependencies:
 - python
 - six
-- numpy
-- scipy
-- matplotlib-base
-- pandas
+- numpy>=1.0
+- matplotlib
+- pandas>=0.17
 - numkit

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(name="GromacsWrapper",
                         'numkit',       # numerical helpers
                         'matplotlib',
                         ],
-      tests_require=['pytest', 'numpy>=1.0', 'pandas>=0.17'],
+      tests_require=['pytest', 'pandas>=0.17'],
       zip_safe=True,
       )


### PR DESCRIPTION
- fix #253 
- use micromamba instead of mamba
- use CODECOV_TOKEN for codecov