### PR TITLE
ci: try a simple ci.yaml (experiment)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,8 +81,6 @@ jobs:
         create-args: >-
            python=${{ matrix.python-version }}.*=*_cpython
            gromacs==${{ matrix.gromacs-version }}
-    
-    - run: micromamba install pocl
 
     - name: Python version information ${{ matrix.python-version }}
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,8 @@ jobs:
         create-args: >-
            python=${{ matrix.python-version }}.*=*_cpython
            gromacs==${{ matrix.gromacs-version }}
+    
+    - run: micromamba install pocl
 
     - name: Python version information ${{ matrix.python-version }}
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: micromamba environment and package installation (Python ${{ matrix.python-version }})
+    - name: micromamba package and testing environment installation (Python ${{ matrix.python-version }}, GROMACS ${{ matrix.gromacs-version }})
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: ci/conda-envs/test_env.yaml
@@ -94,6 +94,8 @@ jobs:
          micromamba info
          micromamba list
          cat /proc/cpuinfo || (/usr/sbin/system_profiler SPHardwareDataType; /usr/sbin/sysctl -a | grep machdep.cpu)
+         micromamba list | grep gromacs | grep ${{ matrix.gromacs-version }}
+         micromamba list | grep python | grep ${{ matrix.python-version }}
 
     - name: Install package (with no dependencies)
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         gromacs-version: ["2023.1"]
         # Test other GROMACS versions selectively on a recent Python.
         # On macOS only test one GROMACS version and two Python versions
@@ -80,6 +80,7 @@ jobs:
         cache-environment: true
         create-args: >-
            python=${{ matrix.python-version }}.*=*_cpython
+           gromacs==${{ matrix.gromacs-version }}
 
     - name: Python version information ${{ matrix.python-version }}
       run: |
@@ -90,17 +91,6 @@ jobs:
          micromamba info
          micromamba list
          cat /proc/cpuinfo || (/usr/sbin/system_profiler SPHardwareDataType; /usr/sbin/sysctl -a | grep machdep.cpu)
-
-    - name: Install pytest and plugins
-      run: |
-         micromamba install pytest pytest-pep8 pytest-cov codecov
-
-    - name: Install GROMACS (${{ matrix.gromacs-version }})
-      # UGLY HACK/FIX (probably to issues with bioconda packages)
-      # - For 3.9, micromamba insists on using pypy 3.9 (and --py-pin does not help).
-      # We can't freeze because then it's not possible to install older GROMACS versions from bioconda. 
-      run: |
-         micromamba install 'gromacs==${{ matrix.gromacs-version }}' pocl numkit python=${{ matrix.python-version }}.*=*_cpython
 
     - name: Install package (with no dependencies)
       run: |

--- a/ci/conda-envs/test_env.yaml
+++ b/ci/conda-envs/test_env.yaml
@@ -1,9 +1,14 @@
-name: test
+name: gromacs_wrapper
 channels:
 - conda-forge
 dependencies:
-- python
-- numpy>=1.0
 - matplotlib
-- pandas>=0.17
 - numkit>=1.0
+- numpy>=1.0
+- pandas>=0.17
+- pocl
+# dev tools
+- codecov
+- pytest 
+- pytest-cov 
+- pytest-pep8 

--- a/ci/conda-envs/test_env.yaml
+++ b/ci/conda-envs/test_env.yaml
@@ -1,3 +1,4 @@
+# it is important to install gromacs together with everything else to ensure correct dependency resolution
 name: gromacs_wrapper
 channels:
 - conda-forge


### PR DESCRIPTION
When setting up to work on this repo, I found the setup very challenging. There is no setup script, so I worked based on what the ci.yaml does – and that contained a number of curveballs. Luckily things can be simplified and everything still works!