### PR TITLE
fix `SyntaxWarning: invalid escape sequence`

### DIFF
--- a/gromacs/fileformats/mdp.py
+++ b/gromacs/fileformats/mdp.py
@@ -58,7 +58,7 @@ class MDP(odict, utilities.FileUtils):
     COMMENT = re.compile("""\s*;\s*(?P<value>.*)""")  # eat initial ws
     # see regex in cbook.edit_mdp()
     PARAMETER = re.compile(
-        """
+        r"""
                             \s*(?P<parameter>[^=]+?)\s*=\s*  # parameter (ws-stripped), before '='
                             (?P<value>[^;]*)                # value (stop before comment=;)
                             (?P<comment>\s*;.*)?            # optional comment

--- a/gromacs/fileformats/ndx.py
+++ b/gromacs/fileformats/ndx.py
@@ -82,7 +82,7 @@ class NDX(odict, utilities.FileUtils):
     default_extension = "ndx"
 
     # match:  [ index_groupname ]
-    SECTION = re.compile("""\s*\[\s*(?P<name>\S.*\S)\s*\]\s*""")
+    SECTION = re.compile(r"""\s*\[\s*(?P<name>\S.*\S)\s*\]\s*""")
 
     #: standard ndx file format: 15 columns
     ncol = 15

--- a/gromacs/fileformats/xpm.py
+++ b/gromacs/fileformats/xpm.py
@@ -115,7 +115,7 @@ class XPM(utilities.FileUtils):
     #:
     #: .. _`printable ASCII character`: http://www.danshort.com/ASCIImap/indexhex.htm
     COLOUR = re.compile(
-        r"""\
+        r"""
             ^.*"                   # start with quotation mark
             (?P<symbol>[\x20-\x7E])# printable ASCII symbol used in the actual pixmap: 'space' to '~'
             \s+                    # white-space separated

--- a/gromacs/fileformats/xpm.py
+++ b/gromacs/fileformats/xpm.py
@@ -115,7 +115,7 @@ class XPM(utilities.FileUtils):
     #:
     #: .. _`printable ASCII character`: http://www.danshort.com/ASCIImap/indexhex.htm
     COLOUR = re.compile(
-        """\
+        r"""\
             ^.*"                   # start with quotation mark
             (?P<symbol>[\x20-\x7E])# printable ASCII symbol used in the actual pixmap: 'space' to '~'
             \s+                    # white-space separated


### PR DESCRIPTION
```
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/gromacs/fileformats/mdp.py:61: SyntaxWarning: invalid escape sequence '\s'
  COMMENT = re.compile("""\s*;\s*(?P<value>.*)""")  # eat initial ws
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/gromacs/fileformats/mdp.py:64: SyntaxWarning: invalid escape sequence '\s'
  """
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/gromacs/fileformats/ndx.py:89: SyntaxWarning: invalid escape sequence '\s'
  SECTION = re.compile("""\s*\[\s*(?P<name>\S.*\S)\s*\]\s*""")
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/gromacs/fileformats/xpm.py:122: SyntaxWarning: invalid escape sequence '\s'
  """\
```