### PR TITLE
fix "DeprecationWarning: invalid escape sequence '\s'"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,12 @@
  CHANGELOG for GromacsWrapper
 ==============================
 
+2024-??-??      0.9.1
+
+* fixed reporting of failures of GromacsCommand and DeprecationWarnings for use
+  of \s in regular expression strings (#285)
+
+
 2024-06-15      0.9.0
 orbeckst, jandom, njzjz
 

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -434,8 +434,8 @@ class GromacsCommand(Command):
 
     command_name = None
     driver = None
-    doc_pattern = """.*?(?P<DOCS>DESCRIPTION.*)"""
-    gmxfatal_pattern = """----+\n                   # ---- decorator line
+    doc_pattern = r""".*?(?P<DOCS>DESCRIPTION.*)"""
+    gmxfatal_pattern = r"""----+\n                  # ---- decorator line
             \s*Program\s+(?P<program_name>\w+),     #  Program name,
               \s+VERSION\s+(?P<version>[\w.]+)\s*\n #    VERSION 4.0.5
             (?P<message>.*?)\n                      # full message, multiple lines

--- a/gromacs/core.py
+++ b/gromacs/core.py
@@ -435,12 +435,13 @@ class GromacsCommand(Command):
     command_name = None
     driver = None
     doc_pattern = r""".*?(?P<DOCS>DESCRIPTION.*)"""
-    gmxfatal_pattern = r"""----+\n                  # ---- decorator line
-            \s*Program\s+(?P<program_name>\w+),     #  Program name,
-              \s+VERSION\s+(?P<version>[\w.]+)\s*\n #    VERSION 4.0.5
-            (?P<message>.*?)\n                      # full message, multiple lines
-            \s*                                     # empty line (?)
-            ----+\n                                 # ---- decorator line
+    # gmxfatal_pattern is used with re.X | re.DOTALL so no need to match \n
+    gmxfatal_pattern = r"""----+\s*                       # ---- decorator line
+            \s*Program:?\s+(?P<program_name>[^,]+),\s*    # Program[:] gmx grompp
+            \s+(VERSION|version)\s+(?P<version>[^\s]+)\s* # VERSION 4.0.5, version 2023.1-macports
+            (?P<message>.*?)                              # full message, multiple lines
+            \s*                                           # empty line (?)
+            ----+                                         # ---- decorator line
             """
     # matches gmx_fatal() output
     # -------------------------------------------------------

--- a/gromacs/tools.py
+++ b/gromacs/tools.py
@@ -626,7 +626,7 @@ class Release(object):
     """
 
     gromacs_version = re.compile(
-        "^G[rR][oO][mM][aA][cC][sS] version:" "\s*(VERSION)?\s*(?P<version>.+)$"
+        r"^G[rR][oO][mM][aA][cC][sS] version:" "\s*(VERSION)?\s*(?P<version>.+)$"
     )
 
     def __init__(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,3 +81,25 @@ class TestCommand(object):
         captured = capsys.readouterr()
         assert command.command_name in captured.out
         assert gromacs.core.Command.__call__.__doc__ in captured.out
+
+
+class TestGromacsCommand:
+    def test_check_failure_raise(self):
+        assert gromacs.grompp.failuremode == "raise"
+        with pytest.raises(gromacs.GromacsError,
+                           match="Gromacs tool failed.*\nCommand invocation:.*grompp"):
+            gromacs.grompp()
+
+    def test_check_failure_warn(self):
+        grompp = gromacs.tools.Grompp(failure="warn")
+        assert grompp.failuremode == "warn"
+        with pytest.warns(gromacs.GromacsFailureWarning,
+                           match="Error code"):
+            rc, stout, stderr = grompp()
+        assert rc == 1 or rc == 255   # almost all GMX or GMX 4.6.5
+
+    def test_check_failure_none(self):
+        grompp = gromacs.tools.Grompp(failure=None)
+        assert grompp.failuremode == None
+        rc, stout, stderr = grompp()
+        assert rc == 1 or rc == 255   # almost all GMX or GMX 4.6.5


### PR DESCRIPTION
fix #285 