### PR TITLE
add automated deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,55 @@
+name: Build and upload to PyPi
+
+on:
+  push:
+    tags:
+      - "*"
+  release:
+    types:
+      - published
+
+jobs:
+  test_pypi_push:
+    environment:
+      name: TestPyPi
+      url: https://test.pypi.org/p/GromacsWrapper
+    permissions:
+      id-token: write
+    if: |
+      github.repository == 'Becksteinlab/GromacsWrapper' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    name: "TestPyPi: Build, upload, and test pure Python wheels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: testpypi_deploy
+        uses: MDAnalysis/pypi-deployment@main
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        with:
+          test_submission: true
+          package_name: 'GromacsWrapper'
+          module_name: 'gromacs'
+
+  pypi_push:
+    environment:
+      name: PyPi
+      url: https://pypi.org/p/GromacsWrapper
+    permissions:
+      id-token: write
+    if: |
+      github.repository == 'Becksteinlab/GromacsWrapper' &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    name: "PyPi: Build, upload, and test pure Python wheels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: pypi_deploy
+        uses: MDAnalysis/pypi-deployment@main
+        if: github.event_name == 'release' && github.event.action == 'published'
+        with:
+          package_name: 'GromacsWrapper'
+          module_name: 'gromacs'

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@
  CHANGELOG for GromacsWrapper
 ==============================
 
-2024-??-??      0.9.1
+2024-09-18      0.9.1
 orbeckst, hsk17
 
 * templates in `config.templates` are now stored as
@@ -13,6 +13,8 @@ orbeckst, hsk17
 * fixed reporting of failures of GromacsCommand and DeprecationWarnings for use
   of \s in regular expression strings (#285)
 * fixed use of outdated numpy.NAN | INF by using nan | inf (#290)
+* added automatic deployment workflow (using action MDAnalysis/pypi-deployment)
+  (#295)
 
 
 2024-06-15      0.9.0


### PR DESCRIPTION
- fix #295
- automatically deploy to TestPyPi or PyPi (for releases) using the action MDAnalysis/pypi-deployment
- update CHANGES (ready for 0.9.1 release)